### PR TITLE
Add optional persistence

### DIFF
--- a/dynamodb-local/templates/statefulset.yaml
+++ b/dynamodb-local/templates/statefulset.yaml
@@ -60,7 +60,21 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+  {{- if not .Values.persistence.enabled }}
       volumes:
         - name: storage
           emptyDir:
             sizeLimit: 10Gi
+  {{- else }}
+  volumeClaimTemplates:
+  - metadata:
+      name: storage
+    spec:
+      accessModes: {{ .Values.persistence.accessModes }}
+      {{- with .Values.persistence.storageClassName }}
+      storageClassName: {{ . }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size }}
+  {{- end }}

--- a/dynamodb-local/values.yaml
+++ b/dynamodb-local/values.yaml
@@ -56,3 +56,10 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+persistence:
+  enabled: false
+  # storageClassName: default
+  accessModes:
+    - ReadWriteOnce
+  size: 10Gi


### PR DESCRIPTION
Add optional persistence storage to the chart. The default configuration is unchanged.

Thanks for saving me a job writing this!